### PR TITLE
styling: centering gauge + added background to card

### DIFF
--- a/canvas-gauge-card.js
+++ b/canvas-gauge-card.js
@@ -66,6 +66,7 @@ class CanvasGaugeCard extends HTMLElement {
                     width: ${elemContainer.width}px;
                     height: calc(${elemContainer.height}px + ${this.config.shadow_bottom ? this.config.shadow_bottom : 0}px);
                     position: relative;
+                    margin: auto;
                 }
                 #container {
                     width: ${elemContainer.width}px;

--- a/canvas-gauge-card.js
+++ b/canvas-gauge-card.js
@@ -62,6 +62,13 @@ class CanvasGaugeCard extends HTMLElement {
         // The styles
         const style = `
             <style>
+                :host {
+                    box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
+                    display: block !important;
+                    border-radius: 2px !important;
+                    transition: all 0.30s ease-out !important;
+                    background-color: white !important;
+                }
                 #cardroot {
                     width: ${elemContainer.width}px;
                     height: calc(${elemContainer.height}px + ${this.config.shadow_bottom ? this.config.shadow_bottom : 0}px);


### PR DESCRIPTION
Added a css property as to center the gauge on the card and css code to give the card a background and box-shadow just like the standard cards.

I thought users would expect it to look and feel more like the standard cards, but it's ok to dismiss this request if you don't agree, it's your work after all.